### PR TITLE
[fix] #231

### DIFF
--- a/backend/src/main/java/com/woowacourse/edd/exceptions/DuplicateEmailSignUpException.java
+++ b/backend/src/main/java/com/woowacourse/edd/exceptions/DuplicateEmailSignUpException.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public class DuplicateEmailSignUpException extends ErrorResponseException {
 
-    public static final String DUPLICATE_EMAIL_SIGNUP_MESSAGE = "이미 존재하는 이메일입니다.";
+    public static final String DUPLICATE_EMAIL_SIGNUP_MESSAGE = "이미 존재하거나 탈퇴한 회원의 이메일은 사용하실 수 없습니다.";
 
     public DuplicateEmailSignUpException() {
         super(DUPLICATE_EMAIL_SIGNUP_MESSAGE, HttpStatus.BAD_REQUEST);

--- a/backend/src/main/java/com/woowacourse/edd/exceptions/InvalidUserNameException.java
+++ b/backend/src/main/java/com/woowacourse/edd/exceptions/InvalidUserNameException.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidUserNameException extends ErrorResponseException {
 
-    public static final String INVALID_USER_NAME_MESSAGE = "올바르지 않은 사용자 이름입니다.";
+    public static final String INVALID_USER_NAME_MESSAGE = "이름은 영어 또는 한글만 가능합니다.";
 
     public InvalidUserNameException() {
         super(INVALID_USER_NAME_MESSAGE, HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
 - 닉네임이 영어, 한글이 가능하다고 변경
 - 이메일이 중복된다고 할 때 탈퇴한 회원 이메일도 사용하지 못한다고 추가